### PR TITLE
feat: improve en-US intent definitions

### DIFF
--- a/ovos_skill_wolfie/locale/en-US/Help.voc
+++ b/ovos_skill_wolfie/locale/en-US/Help.voc
@@ -1,0 +1,6 @@
+# meta requests about the assistant itself — these must not be forwarded to
+# Wolfram Alpha as knowledge queries by the fallback handler
+install
+skills
+what can you do
+help

--- a/ovos_skill_wolfie/locale/en-US/query.blacklist
+++ b/ovos_skill_wolfie/locale/en-US/query.blacklist
@@ -1,0 +1,14 @@
+# values that must not fill the {query} slot of search_wolfie.intent
+# bare anaphoric pronouns carry no query on their own: an utterance like
+# "ask wolfram about it" must leave {query} unresolved so a later stage
+# (OVOS-CONTEXT-1 §7 context fill or a re-prompt) supplies the referent,
+# instead of sending the literal word "it" to Wolfram Alpha.
+he
+she
+they
+it
+him
+her
+them
+this
+that

--- a/ovos_skill_wolfie/locale/en-US/search_wolfie.intent
+++ b/ovos_skill_wolfie/locale/en-US/search_wolfie.intent
@@ -1,9 +1,8 @@
-ask the wolf {query}
-ask the wolfram about {query}
-ask the wolfram alpha about {query}
-search the wolf for {query}
-search wolfram alpha for {query}
-search wolfram for {query}
-what does the wolf say about {query}
-what does wolfram alpha say about {query}
-what does wolfram say about {query}
+ask <wolfram> [about] {query}
+tell <wolfram> [about] {query}
+query <wolfram> [about|for] {query}
+search <wolfram> for {query}
+search [for] {query} (on|with|using|in) <wolfram>
+look up {query} (on|with|using|in) <wolfram>
+what does <wolfram> say about {query}
+according to <wolfram> {query}

--- a/ovos_skill_wolfie/locale/en-US/wolfram.voc
+++ b/ovos_skill_wolfie/locale/en-US/wolfram.voc
@@ -1,0 +1,5 @@
+# names the user can use to address the Wolfram Alpha backend
+wolfram
+wolfram alpha
+the wolf
+wolfie

--- a/test/unittests/test_skill.py
+++ b/test/unittests/test_skill.py
@@ -212,5 +212,48 @@ class TestCqCallback(unittest.TestCase):
         self.skill.gui.show_page.assert_not_called()
 
 
+# ---------------------------------------------------------------------------
+# Locale resources — en-US intent definitions
+# ---------------------------------------------------------------------------
+
+class TestEnUsLocaleResources(unittest.TestCase):
+    """Guard the shape of the packaged en-US resources the skill relies on."""
+
+    def _locale(self, name):
+        import os
+        import ovos_skill_wolfie
+        path = os.path.join(os.path.dirname(ovos_skill_wolfie.__file__),
+                            "locale", "en-US", name)
+        with open(path) as f:
+            return [ln.strip() for ln in f
+                    if ln.strip() and not ln.strip().startswith("#")]
+
+    def test_help_voc_present(self):
+        # handle_wolfram_fallback voc_matches "Help"; the file must ship so
+        # meta requests are not forwarded to Wolfram Alpha
+        self.assertIn("install", self._locale("Help.voc"))
+
+    def test_intent_uses_wolfram_voc(self):
+        # every explicit template names the backend via the <wolfram> voc,
+        # so none acts as a bare open-{query} catcher
+        lines = self._locale("search_wolfie.intent")
+        self.assertTrue(lines)
+        for line in lines:
+            self.assertIn("{query}", line)
+            self.assertIn("<wolfram>", line)
+
+    def test_wolfram_voc_names(self):
+        names = self._locale("wolfram.voc")
+        self.assertIn("wolfram", names)
+        self.assertIn("the wolf", names)
+
+    def test_query_blacklist_excludes_pronouns(self):
+        # anaphoric pronouns must not fill {query} (INTENT-2 §4.3 slot-value
+        # exclusion) so CONTEXT-1 §7 can resolve the referent
+        excluded = self._locale("query.blacklist")
+        for pronoun in ("it", "he", "she", "they", "this", "that"):
+            self.assertIn(pronoun, excluded)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Improve the en-US intent definitions of the explicit Wolfram Alpha intent for coverage and spec conformance, without letting the registered intent over-grab generic knowledge questions.

### Changes (en-US only)
- **`wolfram.voc` + inline `<wolfram>`** — `search_wolfie.intent` now references a `<wolfram>` vocabulary (`wolfram`, `wolfram alpha`, `the wolf`, `wolfie`) and uses expansion `(a|b)`/`[x]` to broaden verb/preposition phrasings (`ask`/`tell`/`query`/`search`/`look up`/`according to`). Every template stays anchored to an explicit backend mention.
- **No open-query over-grab** — bare `open {query}` utterances remain the job of the `common_query` handler and the priority-91 fallback, never a high-priority padatious intent (same discipline as wikihow #77). All templates keep `{query}` bounded by explicit keywords.
- **`query.blacklist` (INTENT-2 §4.3 slot-value exclusion)** — anaphoric pronouns (`he`, `she`, `they`, `it`, `him`, `her`, `them`, `this`, `that`) must not fill `{query}`. So *"ask wolfram about it"* leaves `{query}` unresolved for OVOS-CONTEXT-1 §7 context fill instead of sending the literal word "it" to Wolfram Alpha.
- **`Help.voc`** — `handle_wolfram_fallback` already `voc_match`es `"Help"`, but the file was missing from the packaged locale, so help/meta requests silently leaked to the Wolfram fallback. Now shipped.

### Tests
- Added `TestEnUsLocaleResources` guarding: `Help.voc` present, every intent line names `<wolfram>` and carries `{query}`, `wolfram.voc` names, pronoun exclusion in `query.blacklist`.
- Full suite: **23 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)